### PR TITLE
Update documentation on character range used for UNIQUE_ID

### DIFF
--- a/docs/manual/mod/mod_unique_id.xml
+++ b/docs/manual/mod/mod_unique_id.xml
@@ -160,7 +160,7 @@ identifier for each request</description>
     constructed by encoding the 144-bit (32-bit IP address, 32 bit
     pid, 32 bit time stamp, 16 bit counter, 32 bit thread index)
     quadruple using the
-    alphabet <code>[A-Za-z0-9@-]</code> in a manner similar to MIME
+    alphabet <code>[A-Za-z0-9_-]</code> in a manner similar to MIME
     base64 encoding, producing 24 characters. The MIME base64
     alphabet is actually <code>[A-Za-z0-9+/]</code> however
     <code>+</code> and <code>/</code> need to be specially encoded


### PR DESCRIPTION
This was changed by https://bz.apache.org/bugzilla/show_bug.cgi?id=57044.